### PR TITLE
fix: resolve Telegram bot silent failure with polling watchdog and he…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,12 @@ services:
       - ./node-gateway/src:/app/src
       - ./proto:/proto
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/health/live', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   # ============================
   # Python Tax Engine Service

--- a/node-gateway/src/api/routes/health.ts
+++ b/node-gateway/src/api/routes/health.ts
@@ -1,6 +1,14 @@
 import { Router, Request, Response } from 'express';
 import Redis from 'ioredis';
 import { config } from '../../config';
+import type { TelegramAdapter } from '../../channels/telegram/bot';
+
+let _telegramAdapter: TelegramAdapter | null = null;
+
+/** Call once at startup so the health route can report polling status */
+export function setTelegramAdapter(adapter: TelegramAdapter): void {
+  _telegramAdapter = adapter;
+}
 
 const router = Router();
 
@@ -18,6 +26,11 @@ router.get('/health', async (_req: Request, res: Response) => {
     checks.redis = 'ok';
   } catch {
     checks.redis = 'error';
+  }
+
+  // Check Telegram polling (only in non-production / polling mode)
+  if (_telegramAdapter && !(config.app.isProduction && config.telegram.webhookUrl)) {
+    checks.telegramPolling = _telegramAdapter.isPollingHealthy() ? 'ok' : 'error';
   }
 
   const allHealthy = Object.values(checks).every((v) => v === 'ok');

--- a/node-gateway/src/channels/telegram/bot.ts
+++ b/node-gateway/src/channels/telegram/bot.ts
@@ -47,14 +47,27 @@ export class TelegramAdapter implements ChannelAdapter {
   readonly channel = 'telegram' as const;
   private bot: Telegraf;
   private messageHandler: MessageHandler | null = null;
+  private lastUpdateTime = Date.now();
+  private watchdogTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** Check if bot polling is considered alive (received update within threshold) */
+  isPollingHealthy(thresholdMs = 120_000): boolean {
+    return Date.now() - this.lastUpdateTime < thresholdMs;
+  }
 
   constructor() {
     this.bot = new Telegraf(config.telegram.botToken);
   }
 
   async initialize(): Promise<void> {
+    // === Global error handler — catches middleware & handler errors ===
+    this.bot.catch((err: unknown) => {
+      logger.error('Telegraf caught error', { error: err });
+    });
+
     // Register message handler
     this.bot.on('message', async (ctx: Context<Update.MessageUpdate>) => {
+      this.lastUpdateTime = Date.now();
       try {
         const message = mapTelegramMessage(ctx);
         if (message && this.messageHandler) {
@@ -67,6 +80,7 @@ export class TelegramAdapter implements ChannelAdapter {
 
     // Handle inline keyboard button clicks (callback_query)
     this.bot.on('callback_query', async (ctx) => {
+      this.lastUpdateTime = Date.now();
       try {
         // Acknowledge the callback to remove loading state on the button
         await ctx.answerCbQuery();
@@ -143,6 +157,23 @@ export class TelegramAdapter implements ChannelAdapter {
       await this.bot.telegram.deleteWebhook({ drop_pending_updates: false });
       await this.bot.launch({ dropPendingUpdates: false });
       logger.info('Telegram bot started in polling mode');
+
+      // Watchdog: if no updates received for 2 minutes, restart polling.
+      // Telegraf polling can silently die after network hiccups.
+      this.watchdogTimer = setInterval(async () => {
+        if (!this.isPollingHealthy()) {
+          logger.warn('Telegram polling watchdog: no updates for 2 min, restarting polling');
+          try {
+            this.bot.stop('SIGTERM');
+            await this.bot.telegram.deleteWebhook({ drop_pending_updates: false });
+            await this.bot.launch({ dropPendingUpdates: false });
+            this.lastUpdateTime = Date.now();
+            logger.info('Telegram polling restarted by watchdog');
+          } catch (err) {
+            logger.error('Watchdog failed to restart polling', { error: err });
+          }
+        }
+      }, 60_000);
     }
   }
 
@@ -216,6 +247,10 @@ export class TelegramAdapter implements ChannelAdapter {
   }
 
   async shutdown(): Promise<void> {
+    if (this.watchdogTimer) {
+      clearInterval(this.watchdogTimer);
+      this.watchdogTimer = null;
+    }
     try {
       this.bot.stop('SIGTERM');
     } catch {

--- a/node-gateway/src/index.ts
+++ b/node-gateway/src/index.ts
@@ -7,6 +7,7 @@ import { ZaloAdapter } from './channels/zalo/oa';
 import { TaxEngineClient } from './grpc/client';
 import { MessageRouter } from './router/messageRouter';
 import { createServer } from './api/server';
+import { setTelegramAdapter } from './api/routes/health';
 
 async function bootstrap(): Promise<void> {
   logger.info('Starting Tax Assistant Gateway...', { env: config.app.env });
@@ -35,6 +36,9 @@ async function bootstrap(): Promise<void> {
   // === Start channel adapters ===
   await telegramAdapter.initialize();
   await zaloAdapter.initialize();
+
+  // Expose adapter to health check so it can report polling status
+  setTelegramAdapter(telegramAdapter);
 
   // === Start HTTP server ===
   const app = createServer({ sessionStore, zaloAdapter, telegramAdapter });


### PR DESCRIPTION
…alth check

Root cause: Telegraf polling silently dies after network hiccups — process stays alive but stops fetching updates (zombie state). No error handler or health check could detect this.

Changes:
- Add bot.catch() global error handler for Telegraf middleware errors
- Track lastUpdateTime on every message/callback to detect polling death
- Add 60s watchdog that restarts polling if no updates for 2 minutes
- Expose telegramPolling status in /health endpoint (non-production only)
- Add Docker healthcheck using /health/live for container liveness
- Clean up watchdog timer on graceful shutdown

https://claude.ai/code/session_01Ga2sPxDKN2dXCGXjhZS2JB